### PR TITLE
Fix: output_func string format

### DIFF
--- a/src/programy/parser/template/nodes/base.py
+++ b/src/programy/parser/template/nodes/base.py
@@ -41,7 +41,7 @@ class TemplateNode(object):
 
     def output_child(self, node, tabs, eol, output_func):
         for child in node.children:
-            output_func("%s{%s}%s" % (tabs, child.to_string(), eol))
+            output_func("{0}{{1}}{2}".format(tabs, child.to_string(), eol))
             self.output_child(child, tabs + "\t", eol, output_func)
 
     def resolve_children_to_string(self, bot, clientid):


### PR DESCRIPTION
I get a UnicodeEncodeError when running y-bot for the first time.

I'm running 'Python 3.6.2' on Linux.

Here's how to recreate:

```
git clone repo
pip install -r requirements.txt
cd bots/y-bot
./y-bot.sh
```

This is the error:
```
$ ./y-bot.sh 

Loading, please wait...
No bot root argument set, defaulting to [.]
Traceback (most recent call last):
  File "../../src/programy/clients/console.py", line 73, in <module>
    run()
  File "../../src/programy/clients/console.py", line 70, in run
    console_app = ConsoleBotClient()
  File "../../src/programy/clients/console.py", line 25, in __init__
    BotClient.__init__(self, argument_parser)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/clients/client.py", line 36, in __init__
    self._brain = Brain(self.configuration.brain_configuration)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/brain.py", line 70, in __init__
    self.load(self._configuration)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/brain.py", line 183, in load
    self.load_aiml(brain_configuration)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/brain.py", line 166, in load_aiml
    self._aiml_parser.load_aiml(brain_configuration)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/aiml_parser.py", line 134, in load_aiml
    self.pattern_parser.dump_to_file(brain_configuration.binaries.dump_to_file)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/graph.py", line 240, in dump_to_file
    self.dump(output_func=dump_file.write, eol="\n")
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/graph.py", line 235, in dump
    self.root.dump("", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 383, in dump
    self._0ormore_hash.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 396, in dump
    child.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 383, in dump
    self._0ormore_hash.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 396, in dump
    child.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 396, in dump
    child.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 389, in dump
    self._topic.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 387, in dump
    self._1ormore_star.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 391, in dump
    self._that.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 387, in dump
    self._1ormore_star.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 393, in dump
    self._template.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/pattern/nodes/base.py", line 393, in dump
    self._template.dump(tabs+"\t", output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/template/nodes/base.py", line 37, in dump
    self.output(tabs, output_func, eol, verbose)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/template/nodes/base.py", line 40, in output
    self.output_child(self, tabs, eol, output_func)
  File "/home/alex/go/src/github.com/keiffster/program-y/src/programy/parser/template/nodes/base.py", line 44, in output_child
    output_func("%s{%s}%s" % (tabs, child.to_string(), eol))
UnicodeEncodeError: 'ascii' codec can't encode character '\xa3' in position 18: ordinal not in range(128)

```
